### PR TITLE
Remove redundant title attributes from modal buttons for cleaner code…

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,7 @@
     </header>
 
     <!-- Help Modal Button -->
-    <button class="w3-button w3-blue w3-margin" onclick="toggleModal('helpModal', true)"
-      title="Open the Help Modal to Learn How to Use the Pomodoro Timer Effectively" aria-controls="helpModal">
+    <button class="w3-button w3-blue w3-margin" onclick="toggleModal('helpModal', true)" aria-controls="helpModal">
       <i class="w3-margin-right" aria-hidden="true">ℹ️</i>How it Works?
     </button>
 
@@ -30,7 +29,7 @@
       <div class="w3-modal-content w3-padding">
         <!-- Close button for Help Modal -->
         <span onclick="toggleModal('helpModal', false)" class="w3-button w3-display-topright"
-          aria-label="Close Help Modal" title="Close the Help Modal"><i class="fas fa-times" aria-hidden="true"></i></span>
+          aria-label="Close Help Modal"><i class="fas fa-times" aria-hidden="true"></i></span>
         <!-- Help Modal Content -->
         <h2 id="helpModalTitle">How to Use the Pomodoro Timer</h2>
         <p><strong>Focus Time:</strong> Work without distractions.</p>
@@ -58,9 +57,7 @@
     </div>
 
     <!-- Settings Button -->
-    <button class="w3-button w3-blue w3-margin" onclick="toggleModal('settingsModal', true)"
-      title="Open the Settings Modal to Configure Timer Preferences, Notifications, and Presets"
-      aria-controls="settingsModal">
+    <button class="w3-button w3-blue w3-margin" onclick="toggleModal('settingsModal', true)" aria-controls="settingsModal">
       <i class="w3-margin-right" aria-hidden="true">⚙️</i>Settings
     </button>
 
@@ -69,7 +66,7 @@
       <div class="w3-modal-content w3-padding">
         <!-- Close button for Settings Modal -->
         <span onclick="toggleModal('settingsModal', false)" class="w3-button w3-display-topright"
-          aria-label="Close Settings Modal" title="Close the Settings Modal"><i class="fas fa-times"></i></span>
+          aria-label="Close Settings Modal"><i class="fas fa-times"></i></span>
         <!-- Settings Modal Content -->
         <h2 id="settingsModalTitle">Settings</h2>
         <!-- Audio Notification Toggle -->
@@ -193,8 +190,7 @@
         <!-- Timer Controls -->
         <div class="timer-controls">
           <div class="primary-action">
-            <button id="startPauseButton" onclick="toggleTimer()" class="w3-button w3-green"
-              title="Start or Pause the Timer">
+            <button id="startPauseButton" onclick="toggleTimer()" class="w3-button w3-green">
               <i class="fas fa-play"></i> Start
             </button>
           </div>


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Removes redundant title attributes from modal buttons in the Pomodoro Timer interface to improve code cleanliness and accessibility.

- Removed verbose title attributes from the Help Modal button and its close button that duplicated information already available through other accessibility attributes.
- Eliminated redundant title attributes from the Settings Modal button and its close button to reduce code verbosity.
- Removed unnecessary title attribute from the Start/Pause button, relying on the button's visible text for user guidance instead.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

… and improved accessibility.